### PR TITLE
Fix typo in request arguments

### DIFF
--- a/lua/codeium/source.lua
+++ b/lua/codeium/source.lua
@@ -185,7 +185,7 @@ function Source:complete(params, callback)
 			text = text,
 			editor_language = filetype,
 			language = language,
-			curson_position = { row = cursor.row, col = cursor.col },
+			cursor_position = { row = cursor.row, col = cursor.col },
 			absolute_uri = 'file://' .. vim.api.nvim_buf_get_name(bufnr),
 			workspace_uri = 'file://' .. util.get_relative_path(bufnr),
 			line_ending = line_ending,


### PR DESCRIPTION
As discussed at https://github.com/Exafunction/codeium.nvim/pull/220#discussion_r1772445196

I should note that I haven't tested this since I actually use codeium.vim.